### PR TITLE
add pause to run-python34.bat

### DIFF
--- a/run-python34.bat
+++ b/run-python34.bat
@@ -15,3 +15,4 @@ REM
 @echo ON
 
 C:/Python34/python.exe reggie.py
+pause


### PR DESCRIPTION
Adding pause to the .bat file stops the prompt in case you get an error, so you can see and/or report the error.