### PR TITLE
Fix issues with the autosave timer

### DIFF
--- a/reggie.py
+++ b/reggie.py
@@ -17084,10 +17084,6 @@ class ReggieWindow(QtWidgets.QMainWindow):
 
         self.ZoomLevels = [7.5, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0, 75.0, 85.0, 90.0, 95.0, 100.0, 125.0, 150.0, 175.0, 200.0, 250.0, 300.0, 350.0, 400.0]
 
-        self.AutosaveTimer = QtCore.QTimer()
-        self.AutosaveTimer.timeout.connect(self.Autosave)
-        self.AutosaveTimer.start(20000)
-
         # add the undo stack object
         self.undoStack = UndoStack()
 
@@ -17133,8 +17129,13 @@ class ReggieWindow(QtWidgets.QMainWindow):
 
     def __init2__(self):
         """
-        Finishes initialization. (fixes bugs with some widgets calling mainWindow.something before it's init'ed
+        Finishes initialization. (fixes bugs with some widgets calling mainWindow.something before it's init'ed)
         """
+		
+		self.AutosaveTimer = QtCore.QTimer()
+        self.AutosaveTimer.timeout.connect(self.Autosave)
+        self.AutosaveTimer.start(20000)
+		
         # set up actions and menus
         self.SetupActionsAndMenus()
 


### PR DESCRIPTION
Like the title says, this fixes an issue with the autosave timer that was preventing ReggieNext from loading. Specifically, the issue was:
```
QObject::connect: Cannot connect QTimer::timeout() to (null)::Autosave()
Traceback (most recent call last):
  File "reggie.py", line 21567, in <module>
    generateStringsXML = True
  File "reggie.py", line 21555, in main

  File "reggie.py", line 17086, in __init__

TypeError: connect() failed between timeout() and Autosave()
```
Python's not really my language, but I did the best I could at debugging this. I don't know if it's the same way in Python as it is in other languages (where `self`/`this` is a little weird if you use it in the constructor, especially when passing around references to it), but it made me try to move the problematic code to `__init2__`, which fixed the problem for me and lets ReggieNext start up. The best part: autosave still works (my computer crashed a while later due to something else and when I started it back up and opened Reggie, it asked if I wanted to reopen the autosaved file). Don't know if this is the best solution for the issue, but it works!